### PR TITLE
Fix Metadata::length parsing error

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -203,7 +203,11 @@ impl Metadata {
 		self.inner
 			.get("mpris:length")
 			.cloned()
-			.and_then(|v| v.try_into_int().ok())
+			.and_then(|v| match &v {
+				MetadataValue::Int(i) => Some(*i),
+				MetadataValue::Str(s) => s.parse().ok(),
+				_ => None,
+			})
 			.map(Duration::microseconds)
 	}
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -205,6 +205,7 @@ impl Metadata {
 			.cloned()
 			.and_then(|v| match &v {
 				MetadataValue::Int(i) => Some(*i),
+				MetadataValue::UInt(u) => Some(*u as i64),
 				MetadataValue::Str(s) => s.parse().ok(),
 				_ => None,
 			})


### PR DESCRIPTION
Hi. I noticed that for many players `Metadata::length()` returns `None` even if `mpris:length` is present in `Metadata::inner` hashmap. Turns out, those players report it as a string for some reason (even though [the specification requires 64-bit integer](https://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata/#mpris:length)). I tried at least Firefox, Spotify, and Amberol, and this seems to be the case with all of them.

Would you prefer to have this fix, or keep it according to the specification?